### PR TITLE
Fix some CMake warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_policy(SET CMP0048 NEW)
+cmake_minimum_required(VERSION 3.5)
 project(phasephdgr VERSION 0.1.1)
 
-cmake_minimum_required(VERSION 3.0)
 set (CMAKE_CXX_STANDARD 17)
 
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,5 +1,5 @@
+cmake_minimum_required(VERSION 3.5)
 project(pp_python)
-cmake_minimum_required(VERSION 3.0)
 
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 


### PR DESCRIPTION
Fixes a few annoying CMake warnings:
- Minimum CMake version before top-level project.
- Minimum version 3.5 to avoid deprecation issues.